### PR TITLE
Disable google maps scrolling hijack unless clicked

### DIFF
--- a/css/stylish-portfolio.css
+++ b/css/stylish-portfolio.css
@@ -232,6 +232,10 @@ hr.small {
     }
 }
 
+.map iframe{
+    pointer-events: none;
+}
+
 /* Footer */
 
 footer {

--- a/index.html
+++ b/index.html
@@ -298,6 +298,33 @@
             }
         });
     });
+
+    // Disable Google Maps scrolling
+    // See http://stackoverflow.com/a/25904582/1607849
+    // Disable scroll zooming and bind back the click event
+    var onMapMouseleaveHandler = function (event) {
+      var that = $(this);
+
+      that.on('click', onMapClickHandler);
+      that.off('mouseleave', onMapMouseleaveHandler);
+      that.find('iframe').css("pointer-events", "none");
+    }
+
+    var onMapClickHandler = function (event) {
+      var that = $(this);
+
+      // Disable the click handler until the user leaves the map area
+      that.off('click', onMapClickHandler);
+
+      // Enable scrolling zoom
+      that.find('iframe').css("pointer-events", "auto");
+
+      // Handle the mouse leave event
+      that.on('mouseleave', onMapMouseleaveHandler);
+    }
+
+    // Enable map zooming with mouse scroll when the user clicks the map
+    $('.map').on('click', onMapClickHandler);
     </script>
 
 </body>


### PR DESCRIPTION
This might be a useful feature to add with a full-width Google Map (it's something I implemented in my own project). Now the Google Map won't hijack a mouse scroll for resizing the map except between when the user clicks the map and moves her mouse off the map. Based on http://stackoverflow.com/a/25904582/1607849