### PR TITLE
Add npm test script to build with gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "type": "git",
     "url": "https://github.com/BlackrockDigital/startbootstrap-stylish-portfolio.git"
   },
+  "scripts": {
+    "test": "gulp"
+  },
   "dependencies": {
     "bootstrap": "^4.0.0-beta.2",
     "font-awesome": "4.7.0",


### PR DESCRIPTION
Having the script defined allows to run the following command without needing gulp to be installed globally.

```
npm test
```